### PR TITLE
Unique subgraphs for integrators

### DIFF
--- a/subgraphs/amm-v3/config/arbitrum-integrators.json
+++ b/subgraphs/amm-v3/config/arbitrum-integrators.json
@@ -1,0 +1,10 @@
+{
+  "assimFactoryAddr": "0x1134daeAA652E11360631E3CC93e688204D9354b",
+  "configAddr": "0x74982d2fd25cA0e0DeE702e40AfFd93Bae04D3a6",
+  "curveFactoryAddr": "0xDe9c71503648C03F529305e03D259f2eBa9c8fDe",
+  "multisig": "0x69eb9E932A1aBAb2a17893Fa1b0D377602D2F199",
+  "network": "arbitrum-one",
+  "routerAddr": "0xBC3011980ff3462980a8ebC49D8c6585e4624406",
+  "startBlock": 148999521,
+  "zapAddr": "0x60B818c16795ac1cAee5F555F64891e896757771"
+}

--- a/subgraphs/amm-v3/config/mainnet-integrators.json
+++ b/subgraphs/amm-v3/config/mainnet-integrators.json
@@ -1,0 +1,10 @@
+{
+  "assimFactoryAddr": "0xDe9c71503648C03F529305e03D259f2eBa9c8fDe",
+  "configAddr": "0x1020E08935e9F8Ee963356f4C47d7fE8A024c8A7",
+  "curveFactoryAddr": "0xCe2b8E0c196b7F9297A9c168Dfe1A97768297835",
+  "multisig": "0x27E843260c71443b4CC8cB6bF226C3f77b9695AF",
+  "network": "mainnet",
+  "routerAddr": "0x0Bf90521EBd840947845F4466018456AAB08bb09",
+  "startBlock": 18566714,
+  "zapAddr": "0x6FA11A01C00D62BF0ab8AA76Bec9105bF952CdeD"
+}

--- a/subgraphs/amm-v3/config/polygon-integrators.json
+++ b/subgraphs/amm-v3/config/polygon-integrators.json
@@ -1,0 +1,10 @@
+{
+  "assimFactoryAddr": "0x3A3F59467880bd9CABE680e46b23e456B8d903ff",
+  "configAddr": "0x9dDb041C7545d1F644aA57b5b828e8a6c879A11d",
+  "curveFactoryAddr": "0xE5ce84Bba5B27cCfb7D92CB3e1426d8A986854dd",
+  "multisig": "0x80D27bfb638F4Fea1e862f1bd07DEa577CB77D38",
+  "network": "matic",
+  "routerAddr": "0x5cF6d43e4cD920FC7754926a267d46e096baa168",
+  "startBlock": 49699447,
+  "zapAddr": "0x77527E4450236d2E429D667C23Cda4a88C304F21"
+}

--- a/subgraphs/amm-v3/package.json
+++ b/subgraphs/amm-v3/package.json
@@ -11,6 +11,9 @@
     "prepare:mainnet": "mustache config/mainnet.json subgraph.template.yaml > subgraph.yaml && mustache config/mainnet.json src/constants.template.ts > src/constants.ts",
     "prepare:polygon": "mustache config/polygon.json subgraph.template.yaml > subgraph.yaml && mustache config/polygon.json src/constants.template.ts > src/constants.ts",
     "prepare:arbi": "mustache config/arbitrum.json subgraph.template.yaml > subgraph.yaml && mustache config/arbitrum.json src/constants.template.ts > src/constants.ts",
+    "prepare:mainnet:int": "mustache config/mainnet-integrators.json subgraph.template.yaml > subgraph.yaml && mustache config/mainnet-integrators.json src/constants.template.ts > src/constants.ts",
+    "prepare:polygon:int": "mustache config/polygon-integrators.json subgraph.template.yaml > subgraph.yaml && mustache config/polygon-integrators.json src/constants.template.ts > src/constants.ts",
+    "prepare:arbi:int": "mustache config/arbitrum-integrators.json subgraph.template.yaml > subgraph.yaml && mustache config/arbitrum-integrators.json src/constants.template.ts > src/constants.ts",
     "deploy:mainnet": "yarn graph deploy --studio dfx-amm-v3",
     "deploy:polygon": "yarn graph deploy --studio dfx-amm-v3-polygon",
     "deploy:arbi": "yarn graph deploy --studio dfx-amm-v3-arbitrum"


### PR DESCRIPTION
This PR allows generating identical subgraphs that we can provide to integrators like 1Inch with a version of "latest" instead of "0.0.1", etc.

The start block is advanced forward by 1 so subgraph providers will allow a second subgraph for the same code